### PR TITLE
Move package under `@metamask` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This library will register the current page as having initiated onboarding, so t
 
 ## Installation
 
-`metamask-onboarding` is made available as either a CommonJS module, and ES6 module, or an ES5 bundle.
+`@metamask/onboarding` is made available as either a CommonJS module, and ES6 module, or an ES5 bundle.
 
-* ES6 module: `import MetamaskOnboarding from 'metamask-onboarding'`
-* ES5 module: `const MetamaskOnboarding = require('metamask-onboarding')`
+* ES6 module: `import MetamaskOnboarding from '@metamask/onboarding'`
+* ES5 module: `const MetamaskOnboarding = require('@metamask/onboarding')`
 * ES5 bundle: `dist/metamask-onboarding.bundle.js` (this can be included directly in a page)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "metamask-onboarding",
+  "name": "@metamask/onboarding",
   "version": "0.1.1",
   "description": "Tools to support MetaMask one-click onboarding",
   "main": "dist/metamask-onboarding.cjs.js",


### PR DESCRIPTION
Using a single scope should make our packages easier to manage, and make them stand out from community packages.