### PR TITLE
Updates to the package.json metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2018 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/MetaMask/metamask-onboarding.git"
   },
+  "license": "MIT",
   "files": [
     "/src",
     "/dist"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "Tools to support MetaMask one-click onboarding",
   "main": "dist/metamask-onboarding.cjs.js",
   "module": "src/index.js",
-  "repository": "git@github.com:MetaMask/metamask-onboarding.git",
+  "homepage": "https://github.com/MetaMask/metamask-onboarding#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/metamask-onboarding/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/MetaMask/metamask-onboarding.git"
+  },
   "files": [
     "/src",
     "/dist"


### PR DESCRIPTION
This PR updates the `package.json` metadata with:

1. A license, the MIT license that is also used by GABA
2. A `bugs`, `homepage`, and updated `repository` field