### PR TITLE
Add publishConfig metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "type": "git",
     "url": "git+ssh://git@github.com/MetaMask/metamask-onboarding.git"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "license": "MIT",
   "files": [
     "/src",


### PR DESCRIPTION
This PR adds the required `publishConfig` metadata to the `package.json` file to allow `yarn publish` to not think it's a private package. 😅 