### PR TITLE
Add prepublishOnly script to build project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /yarn-error.log
 
 # builds
+*.tgz
 /dist

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "/dist"
   ],
   "scripts": {
-    "prepare": "yarn build",
+    "prepare": "npm run build",
     "build": "rollup --config && rollup --config rollup.config.standalone.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "/dist"
   ],
   "scripts": {
+    "prepare": "yarn build",
     "build": "rollup --config && rollup --config rollup.config.standalone.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "/dist"
   ],
   "scripts": {
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "build": "rollup --config && rollup --config rollup.config.standalone.js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds [a `prepare` script](https://docs.npmjs.com/misc/scripts) entry to make sure that the package is built before it is packed and/or published. I've added tarballs (`*.tgz`) to the `.gitignore` as well.