### PR TITLE
Register onboarding rpc message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/onboarding",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Tools to support MetaMask one-click onboarding",
   "main": "dist/metamask-onboarding.cjs.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -150,11 +150,7 @@ class Onboarding {
   }
 
   static async _register () {
-    if (!window.ethereum._metamask.registerOnboarding) {
-      throw new Error('Onboarding registration not supported by current version of MetaMask')
-    }
-
-    return window.ethereum._metamask.registerOnboarding()
+    return window.ethereum.send('wallet_registerOnboarding')
   }
 
   static _injectForwarder (forwarderOrigin) {


### PR DESCRIPTION
* Use `wallet_registerOnboarding` RPC message
A new `wallet_registerOnboarding` RPC message is now used to register the current site as an onboarding initiator, instead of an experimental `_metamask` method.

* Update version to v0.2.0