### PR TITLE
Remove verbose debug message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/onboarding",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tools to support MetaMask one-click onboarding",
   "main": "dist/metamask-onboarding.cjs.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,8 @@ class Onboarding {
 
   async _onMessage (event) {
     if (event.origin !== this.forwarderOrigin) {
-      return console.debug(`Ignoring non-forwarder message from '${event.origin}' with data ${JSON.stringify(event.data)}`)
+      // Ignoring non-forwarder message
+      return
     }
 
     if (event.data.type === 'metamask:reload') {


### PR DESCRIPTION
This message clutters the web console a great deal. It's especially irritating on mobile because that app sends long messages.