### PR TITLE
Prevent forwarder injection after registration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export default class Onboarding {
 
     window.addEventListener('message', this._onMessage);
 
-    if (forwarderMode === FORWARDER_MODE.INJECT && sessionStorage.getItem(REGISTRATION_IN_PROGRESS)) {
+    if (forwarderMode === FORWARDER_MODE.INJECT && sessionStorage.getItem(REGISTRATION_IN_PROGRESS) === 'true') {
       Onboarding._injectForwarder(this.forwarderOrigin);
     }
   }
@@ -118,7 +118,7 @@ export default class Onboarding {
    * onboarding completes before the forwarder has registered.
    */
   stopOnboarding () {
-    if (sessionStorage.getItem(REGISTRATION_IN_PROGRESS)) {
+    if (sessionStorage.getItem(REGISTRATION_IN_PROGRESS) === 'true') {
       if (this.forwarderMode === FORWARDER_MODE.INJECT) {
         console.debug('Removing forwarder');
         Onboarding._removeForwarder();


### PR DESCRIPTION
There were two truthy checks of an item in session storage that was expected to be a boolean. Instead the item was a string ("true" or "false"). The checks have been updated to expect a string.

This bug was resulting in the library thinking that registration was always in progress, once the `REGISTRATION_IN_PROGRESS` variable was set for the first time.