### PR TITLE
Remove default `iframe` border

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,7 @@ export default class Onboarding {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('height', '0');
     iframe.setAttribute('width', '0');
+    iframe.setAttribute('style', 'display: none;');
     iframe.setAttribute('src', forwarderOrigin);
     iframe.setAttribute('id', FORWARDER_ID);
     container.insertBefore(iframe, container.children[0]);


### PR DESCRIPTION
Default browser styles for `iframe` elements includes a border. A `display: none` rule has been added to prevent the `iframe` from ever being shown.

Fixes #8