### PR TITLE
Use Firefox URL without specified language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const ONBOARDING_STATE = {
 
 const EXTENSION_DOWNLOAD_URL = {
   CHROME: 'https://chrome.google.com/webstore/detail/metamask/nkbihfbeogaeaoehlefnkodbefgpgknn',
-  FIREFOX: 'https://addons.mozilla.org/en-US/firefox/addon/ether-metamask/',
+  FIREFOX: 'https://addons.mozilla.org/firefox/addon/ether-metamask/',
   DEFAULT: 'https://metamask.io',
 };
 


### PR DESCRIPTION
Having `en-US` or any other language in URL for Firefox Addons website will cause website to bo always displayed in that language. Ommiting that part will cause website to automatically determine user's language and show translated content.