### PR TITLE
Fix tsconfig

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@
 !rollup.config.js
 !rollup.config.standalone.js
 dist
+src/*.d.ts
+src/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 # builds
 *.tgz
 /dist
+
+# Built JS
+/src/*.d.ts
+/src/*.js
+/src/*.map

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "moduleResolution": "Node",
     "declaration": true,
     "module": "ES6",
     "sourceMap": true,
@@ -8,9 +9,7 @@
     "lib": [
       "DOM",
       "ES2016"
-    ],
-    // See https://rollupjs.org/guide/en/#installation
-    "types": []
+    ]
   },
   "include": [
     "./**/*.ts"


### PR DESCRIPTION
This PR updates the tsconfig to allow running `tsc --project` successfully.

Previously, running `tsc` would result in the following error:

```bash
$ yarn tsc --project .
```
```
yarn run v1.22.4
$ /metamask-onboarding/node_modules/.bin/tsc --project .
src/index.ts:1:25 - error TS2307: Cannot find module 'bowser' or its corresponding type declarations.

1 import * as Bowser from 'bowser';
                          ~~~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Now it works as expected.

**I've compared the bundle files before & after this change and they are byte-for-byte identical.**