### PR TITLE
Ensure all onboarding states are handled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,10 @@ export default class Onboarding {
     return undefined;
   }
 
+  _onMessageUnknownStateError (state: never): never {
+    throw new Error(`Unknown state: '${state}'`);
+  }
+
   async _onMessageFromForwarder (event: MessageEvent) {
     switch (this.state) {
       case ONBOARDING_STATE.RELOADING:
@@ -84,7 +88,8 @@ export default class Onboarding {
       case ONBOARDING_STATE.NOT_INSTALLED:
         console.debug('Reloading now to register with MetaMask');
         this.state = ONBOARDING_STATE.RELOADING;
-        return location.reload();
+        location.reload();
+        break;
 
       case ONBOARDING_STATE.INSTALLED:
         console.debug('Registering with MetaMask');
@@ -101,9 +106,8 @@ export default class Onboarding {
         console.debug('Already registered - ignoring reload message');
         break;
       default:
-        throw new Error(`Unknown state: '${this.state}'`);
+        this._onMessageUnknownStateError(this.state);
     }
-    return undefined;
   }
 
   /**


### PR DESCRIPTION
~Depends on #43 for the ability to run `tsc`~

This change makes the default case of `_onMessageFromForwarder` of type `never`, which ensures that all of the onboarding states must be contained in the `switch` cases. This change is made possible by the refactor work that @BboyAkers did in #42/#45.

When a state is missing:

```bash
$ git d
```
```diff
@@ -82,9 +82,9 @@ export default class Onboarding {

   async _onMessageFromForwarder (event: MessageEvent) {
     switch (this.state) {
-      case ONBOARDING_STATE.RELOADING:
-        console.debug('Ignoring message while reloading');
-        break;
+      // case ONBOARDING_STATE.RELOADING:
+      //   console.debug('Ignoring message while reloading');
+      //   break;
       case ONBOARDING_STATE.NOT_INSTALLED:
         console.debug('Reloading now to register with MetaMask');
         this.state = ONBOARDING_STATE.RELOADING;
```
```bash
$ yarn tsc --project .
```
```
yarn run v1.22.4
$ tsc --project .
src/index.ts:111:42 - error TS2345: Argument of type '"RELOADING"' is not assignable to parameter of type 'never'.

111         this._onMessageUnknownStateError(this.state);
                                             ~~~~~~~~~~

Found 1 error.
```

TypeScript will flag the default state as trying to assign a state to type `never`.