### PR TITLE
Fix postMessage for registrationCompleted completed event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,7 @@ export default class Onboarding {
         this.state = ONBOARDING_STATE.REGISTERING;
         await Onboarding._register();
         this.state = ONBOARDING_STATE.REGISTERED;
-        if (event.source instanceof Window) {
-          event.source.postMessage({ type: 'metamask:registrationCompleted' }, event.origin);
-        }
+        (event.source as Window).postMessage({ type: 'metamask:registrationCompleted' }, event.origin);
         this.stopOnboarding();
         break;
       case ONBOARDING_STATE.REGISTERING:


### PR DESCRIPTION
This fixes the `registrationCompleted` event in Chrome, per https://github.com/MetaMask/metamask-onboarding/pull/45#discussion_r454102735.