### PR TITLE
Use @metamask/eslint-config@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tslib": "^1.11.0"
   },
   "devDependencies": {
-    "@metamask/eslint-config": "^2.0.0",
+    "@metamask/eslint-config": "^3.1.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@typescript-eslint/eslint-plugin": "^2.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@metamask/eslint-config@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-2.0.0.tgz#4abeccbaafecd2e55be4dc97308e732e2eaa6799"
-  integrity sha512-RowWMIelQNviIH1e9pgsUpQ5oeTXwuzjXAUmW5GXSJz0f3B9MN9OC9krs+ctLZVnf9ec8chcepCTTZFEcVIXRQ==
+"@metamask/eslint-config@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
+  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
 
 "@rollup/plugin-commonjs@^11.0.2":
   version "11.1.0"


### PR DESCRIPTION
This PR updates the `@metamask/eslint-config` dependency to the latest published version, v3.1.0.