### PR TITLE
Remove minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "/src",
     "/dist"
   ],
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
The minimum Node.js version has been removed temporarily, so that we can release a new patch without making a breaking change.