### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1]
+### Changed
+- Update various dependencies ([#49](https://github.com/MetaMask/metamask-onboarding/pull/49), [#68](https://github.com/MetaMask/metamask-onboarding/pull/68), [#71](https://github.com/MetaMask/metamask-onboarding/pull/71))
+- Use `@lavamoat/allow-scripts` for improved security ([#67](https://github.com/MetaMask/metamask-onboarding/pull/67))
+- Remove unused dependencies ([#66](https://github.com/MetaMask/metamask-onboarding/pull/66))
+- Switch from CircleCI to GitHub Actions ([#64](https://github.com/MetaMask/metamask-onboarding/pull/64))
+- Update Node.js used for CI from v10 to v12 ([#59](https://github.com/MetaMask/metamask-onboarding/pull/59), [#73](https://github.com/MetaMask/metamask-onboarding/pull/73))
+- Refactor to improve readability ([#45](https://github.com/MetaMask/metamask-onboarding/pull/45), [#47](https://github.com/MetaMask/metamask-onboarding/pull/47), [#48](https://github.com/MetaMask/metamask-onboarding/pull/48))
+
+### Fixed
+- Fix import of `bowser` package ([#57](https://github.com/MetaMask/metamask-onboarding/pull/57), [#60](https://github.com/MetaMask/metamask-onboarding/pull/60), [#61](https://github.com/MetaMask/metamask-onboarding/pull/61), [#63](https://github.com/MetaMask/metamask-onboarding/pull/63))
+
 ## [1.0.0] - 2020-07-02
 ### Changed
 - **BREAKING**: Rename export to `MetaMaskOnboarding` (#32)
@@ -14,5 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Use Firefox URL without specified language (#38)
 
-[Unreleased]: https://github.com/MetaMask/metamask-onboarding/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-onboarding/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/MetaMask/metamask-onboarding/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/MetaMask/metamask-onboarding/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/onboarding",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Assists with onboarding new MetaMask users",
   "main": "dist/metamask-onboarding.cjs.js",
   "module": "dist/metamask-onboarding.es.js",


### PR DESCRIPTION
This release fixes a build error that make the v1.0.0 bundle and CommonJS builds unusable. It also includes various other less impactful changes.