### PR TITLE
Chore(build): improve bundle size and include source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "license": "MIT",
   "files": [
-    "/src",
     "/dist"
   ],
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,10 +9,12 @@ const config = [
       {
         file: 'dist/metamask-onboarding.cjs.js',
         format: 'cjs',
+        sourcemap: true,
       },
       {
         file: 'dist/metamask-onboarding.es.js',
         format: 'es',
+        sourcemap: true,
       },
     ],
     plugins: [typescript()],


### PR DESCRIPTION
Hello!

While exploring how to use this library I found a couple of low hanging fruits that would help make it better:

- The src folder was being included in the npm package. 
- no source maps were included. 

